### PR TITLE
Activated cross building for Scala 2.10 and Scala 2.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "com.miguno" % "kafka-avro-codec_2.10" % "0.1.1-SNAPSHOT"
+  "com.miguno" %% "kafka-avro-codec" % "0.1.1"
 )
 ```
 
@@ -73,7 +73,7 @@ repositories {
 }
 
 dependencies {
-  compile 'com.miguno:kafka-avro-codec_2.10:0.1.1-SNAPSHOT'
+  compile 'com.miguno:kafka-avro-codec_2.10:0.1.1'
 }
 ```
 
@@ -128,8 +128,8 @@ val consumerMap = consumerConnector.createMessageStreams(topicCountMap, keyDecod
 
 ## Build requirements
 
-* Scala 2.10.3
-* sbt 0.10.3
+* Scala 2.10.5
+* sbt 0.13.8
 * Java JDK 6 or 7
 * [Avro](http://avro.apache.org/) 1.7.6
 

--- a/assembly.sbt
+++ b/assembly.sbt
@@ -1,6 +1,0 @@
-import AssemblyKeys._
-
-assemblySettings
-
-// Any customized settings must be written here, i.e. after 'assemblySettings' above.
-// See https://github.com/sbt/sbt-assembly for available parameters.

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,12 @@
-import sbtrelease.ReleasePlugin._
-
 organization := "com.miguno"
 
 name := "kafka-avro-codec"
 
-scalaVersion := "2.10.3"
+scalaVersion := "2.10.5"
 
-sbtVersion := "0.13.1"
+crossScalaVersions := Seq("2.10.5", "2.11.7")
+
+releaseCrossBuild := true
 
 seq(sbtavro.SbtAvro.avroSettings : _*)
 
@@ -18,22 +18,16 @@ seq(sbtavro.SbtAvro.avroSettings : _*)
 
 (stringType in avroConfig) := "String"
 
-resolvers ++= Seq(
-  "typesafe-repository" at "http://repo.typesafe.com/typesafe/releases/",
-  // Required to retrieve Kafka 0.8.0 release artifacts
-  "Apache releases" at "https://repository.apache.org/content/repositories/releases/"
-)
-
 libraryDependencies ++= Seq(
   // The excludes of jms, jmxtools and jmxri are required as per https://issues.apache.org/jira/browse/KAFKA-974.
   // The exclude of slf4j-simple is because it overlaps with our use of logback with slf4j facade;  without the exclude
   // we get slf4j warnings and logback's configuration is not picked up.
-  "org.apache.kafka" % "kafka_2.10" % "0.8.0"
+  "org.apache.kafka" %% "kafka" % "0.8.2.0"
     exclude("javax.jms", "jms")
     exclude("com.sun.jdmk", "jmxtools")
     exclude("com.sun.jmx", "jmxri")
     exclude("org.slf4j", "slf4j-simple"),
-  "org.scalatest" % "scalatest_2.10" % "2.0" % "test"
+  "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 )
 
 publishMavenStyle := true
@@ -68,5 +62,3 @@ pomExtra := (
       <url>https://github.com/miguno</url>
     </developer>
   </developers>)
-
-releaseSettings

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.10.2")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.8

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,9 @@
 resolvers ++= Seq(
-  "sbt-idea-repo" at "http://mpeltonen.github.com/maven/",
-  "sbt-plugin-releases-repo" at "http://repo.scala-sbt.org/scalasbt/sbt-plugin-releases"
+  "sbt-idea-repo" at "http://mpeltonen.github.com/maven/"
 )
 
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.2")
 
 addSbtPlugin("com.cavorite" % "sbt-avro" % "0.3.2")
+
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.1-SNAPSHOT"
+version in ThisBuild := "0.1.1"


### PR DESCRIPTION
Also:

* Bumped most of the versions to the latest releases (Scala, sbt-release, Kafka, Scalatest). 
* Activated cross building for Scala 2.10 and Scala 2.11. 
* Cleaned various unnecessary build code.
* Removed SNAPSHOT tag (this is quite problematic when used in a build with SBT Release which check that no SNAPSHOT depenencies are present).
* Adjusted the documentation to reflect the above changes.